### PR TITLE
ODP-4167: Set trino to 472.3.2.3.3-3

### DIFF
--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-grammar/pom.xml
+++ b/core/trino-grammar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-parser/pom.xml
+++ b/core/trino-parser/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-server-core/pom.xml
+++ b/core/trino-server-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-server-main/pom.xml
+++ b/core/trino-server-main/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-server/pom.xml
+++ b/core/trino-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/core/trino-web-ui/pom.xml
+++ b/core/trino-web-ui/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
     </parent>
 
     <artifactId>trino-docs</artifactId>

--- a/lib/trino-array/pom.xml
+++ b/lib/trino-array/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-cache/pom.xml
+++ b/lib/trino-cache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-filesystem-alluxio/pom.xml
+++ b/lib/trino-filesystem-alluxio/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-filesystem-azure/pom.xml
+++ b/lib/trino-filesystem-azure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-filesystem-cache-alluxio/pom.xml
+++ b/lib/trino-filesystem-cache-alluxio/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-filesystem-gcs/pom.xml
+++ b/lib/trino-filesystem-gcs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-filesystem-manager/pom.xml
+++ b/lib/trino-filesystem-manager/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-filesystem-s3/pom.xml
+++ b/lib/trino-filesystem-s3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-filesystem/pom.xml
+++ b/lib/trino-filesystem/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-geospatial-toolkit/pom.xml
+++ b/lib/trino-geospatial-toolkit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-hive-formats/pom.xml
+++ b/lib/trino-hive-formats/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-matching/pom.xml
+++ b/lib/trino-matching/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-memory-context/pom.xml
+++ b/lib/trino-memory-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-metastore/pom.xml
+++ b/lib/trino-metastore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-orc/pom.xml
+++ b/lib/trino-orc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/lib/trino-record-decoder/pom.xml
+++ b/lib/trino-record-decoder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-ai-functions/pom.xml
+++ b/plugin/trino-ai-functions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-base-jdbc/pom.xml
+++ b/plugin/trino-base-jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-blackhole/pom.xml
+++ b/plugin/trino-blackhole/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-cassandra/pom.xml
+++ b/plugin/trino-cassandra/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-clickhouse/pom.xml
+++ b/plugin/trino-clickhouse/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-druid/pom.xml
+++ b/plugin/trino-druid/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-duckdb/pom.xml
+++ b/plugin/trino-duckdb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-example-http/pom.xml
+++ b/plugin/trino-example-http/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-example-jdbc/pom.xml
+++ b/plugin/trino-example-jdbc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-exasol/pom.xml
+++ b/plugin/trino-exasol/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-exchange-hdfs/pom.xml
+++ b/plugin/trino-exchange-hdfs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-faker/pom.xml
+++ b/plugin/trino-faker/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-functions-python/pom.xml
+++ b/plugin/trino-functions-python/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-geospatial/pom.xml
+++ b/plugin/trino-geospatial/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-google-sheets/pom.xml
+++ b/plugin/trino-google-sheets/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-http-event-listener/pom.xml
+++ b/plugin/trino-http-event-listener/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-http-server-event-listener/pom.xml
+++ b/plugin/trino-http-server-event-listener/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-ignite/pom.xml
+++ b/plugin/trino-ignite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-jmx/pom.xml
+++ b/plugin/trino-jmx/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-kafka-event-listener/pom.xml
+++ b/plugin/trino-kafka-event-listener/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-loki/pom.xml
+++ b/plugin/trino-loki/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-mariadb/pom.xml
+++ b/plugin/trino-mariadb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-memory/pom.xml
+++ b/plugin/trino-memory/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-ml/pom.xml
+++ b/plugin/trino-ml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-mysql-event-listener/pom.xml
+++ b/plugin/trino-mysql-event-listener/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-opa/pom.xml
+++ b/plugin/trino-opa/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-openlineage/pom.xml
+++ b/plugin/trino-openlineage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-opensearch/pom.xml
+++ b/plugin/trino-opensearch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-password-authenticators/pom.xml
+++ b/plugin/trino-password-authenticators/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-prometheus/pom.xml
+++ b/plugin/trino-prometheus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-ranger/pom.xml
+++ b/plugin/trino-ranger/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-redis/pom.xml
+++ b/plugin/trino-redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-session-property-managers/pom.xml
+++ b/plugin/trino-session-property-managers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-singlestore/pom.xml
+++ b/plugin/trino-singlestore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-snowflake/pom.xml
+++ b/plugin/trino-snowflake/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-spooling-filesystem/pom.xml
+++ b/plugin/trino-spooling-filesystem/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-teradata-functions/pom.xml
+++ b/plugin/trino-teradata-functions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-thrift-api/pom.xml
+++ b/plugin/trino-thrift-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-thrift-testing-server/pom.xml
+++ b/plugin/trino-thrift-testing-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-thrift/pom.xml
+++ b/plugin/trino-thrift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-tpcds/pom.xml
+++ b/plugin/trino-tpcds/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-tpch/pom.xml
+++ b/plugin/trino-tpch/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/plugin/trino-vertica/pom.xml
+++ b/plugin/trino-vertica/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.trino</groupId>
     <artifactId>trino-root</artifactId>
-    <version>472</version>
+    <version>472.3.2.3.3-3</version>
     <packaging>pom</packaging>
 
     <name>${project.artifactId}</name>
@@ -39,7 +39,6 @@
         <module>core/trino-server-main</module>
         <module>core/trino-spi</module>
         <module>core/trino-web-ui</module>
-        <module>docs</module>
         <module>lib/trino-array</module>
         <module>lib/trino-cache</module>
         <module>lib/trino-filesystem</module>
@@ -1575,13 +1574,13 @@
             <dependency>
                 <groupId>io.trino.hadoop</groupId>
                 <artifactId>hadoop-apache</artifactId>
-                <version>3.3.5-3</version>
+                <version>3.3.5-3.3.2.3.3-3</version>
             </dependency>
 
             <dependency>
                 <groupId>io.trino.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>3.1.2-23</version>
+                <version>3.1.2-23.3.2.3.3-3</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.annotation</groupId>
@@ -1601,7 +1600,7 @@
             <dependency>
                 <groupId>io.trino.hive</groupId>
                 <artifactId>hive-apache-jdbc</artifactId>
-                <version>0.13.1-10</version>
+                <version>0.13.1-10-3.2.3.3-3</version>
             </dependency>
 
             <dependency>

--- a/service/trino-proxy/pom.xml
+++ b/service/trino-proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/service/trino-verifier/pom.xml
+++ b/service/trino-verifier/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-benchmark-queries/pom.xml
+++ b/testing/trino-benchmark-queries/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-benchto-benchmarks/pom.xml
+++ b/testing/trino-benchto-benchmarks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-faulttolerant-tests/pom.xml
+++ b/testing/trino-faulttolerant-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-plugin-reader/pom.xml
+++ b/testing/trino-plugin-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-product-tests-groups/pom.xml
+++ b/testing/trino-product-tests-groups/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-server-dev/pom.xml
+++ b/testing/trino-server-dev/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
 
     <properties>
         <!-- Version needs to be hardcoded for the release plugin to work. It will be updated by the release plugin. -->
-        <dep.presto-jdbc-under-test>472</dep.presto-jdbc-under-test>
+        <dep.presto-jdbc-under-test>472.3.2.3.3-3</dep.presto-jdbc-under-test>
     </properties>
 
     <dependencies>

--- a/testing/trino-test-jdbc-compatibility-old-server/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing-kafka/pom.xml
+++ b/testing/trino-testing-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing-resources/pom.xml
+++ b/testing/trino-testing-resources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
-        <version>472</version>
+        <version>472.3.2.3.3-3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Changes in this PR
 - Set trino to 472.3.2.3.3-3
 - use acceldata-io/trino-hive-jdbc
 - use acceldata-io/trino-hive-apache
 - use acceldata-io/hive-thrift
 - use acceldata-io/trino-hadoop-apache
 - remove docker dependency because of trino-docs