### PR TITLE
ODP-5258 : Exclude netty-tcnative-boringssl-static from pinot-core dependency

### DIFF
--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -243,6 +243,10 @@
             <version>${dep.pinot.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>


### PR DESCRIPTION
https://accelcentral.atlassian.net/browse/ODP-5258