### PR TITLE
ODP-5950 Add Hive ACID 4.0.1 support on Trino

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
@@ -163,6 +163,13 @@ public class FailureAwareThriftMetastoreClient
     }
 
     @Override
+    public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics, long writeId, String validWriteIdList)
+            throws TException
+    {
+        runWithHandle(() -> delegate.setTableColumnStatistics(databaseName, tableName, statistics, writeId, validWriteIdList));
+    }
+
+    @Override
     public void deleteTableColumnStatistics(String databaseName, String tableName, String columnName)
             throws TException
     {
@@ -181,6 +188,13 @@ public class FailureAwareThriftMetastoreClient
             throws TException
     {
         runWithHandle(() -> delegate.setPartitionColumnStatistics(databaseName, tableName, partitionName, statistics));
+    }
+
+    @Override
+    public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics, long writeId, String validWriteIdList)
+            throws TException
+    {
+        runWithHandle(() -> delegate.setPartitionColumnStatistics(databaseName, tableName, partitionName, statistics, writeId, validWriteIdList));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -73,6 +73,7 @@ import io.trino.metastore.StatisticsUpdateMode;
 import io.trino.plugin.hive.PartitionNotFoundException;
 import io.trino.plugin.hive.SchemaAlreadyExistsException;
 import io.trino.plugin.hive.TableAlreadyExistsException;
+import io.trino.plugin.hive.util.AcidTables;
 import io.trino.plugin.hive.util.RetryDriver;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.SchemaNotFoundException;
@@ -447,7 +448,7 @@ public final class ThriftHiveMetastore
     private static boolean isTransactionalTable(Table table)
     {
         Map<String, String> parameters = table.getParameters();
-        return parameters != null && "true".equalsIgnoreCase(parameters.get("transactional"));
+        return parameters != null && AcidTables.isTransactionalTable(parameters);
     }
 
     private Optional<String> getValidWriteIdList(String databaseName, String tableName, long writeId)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -428,10 +428,45 @@ public final class ThriftHiveMetastore
                 })
                 .collect(toImmutableList());
         if (!metastoreColumnStatistics.isEmpty()) {
-            setTableColumnStatistics(databaseName, tableName, metastoreColumnStatistics);
+            // For transactional tables, use the API that supports writeId
+            if (isTransactionalTable(originalTable) && acidWriteId.isPresent()) {
+                Optional<String> validWriteIdList = getValidWriteIdList(databaseName, tableName, acidWriteId.getAsLong());
+                setTableColumnStatistics(databaseName, tableName, metastoreColumnStatistics, acidWriteId, validWriteIdList);
+            }
+            else {
+                setTableColumnStatistics(databaseName, tableName, metastoreColumnStatistics);
+            }
         }
         Set<String> removedColumnStatistics = difference(currentStatistics.columnStatistics().keySet(), updatedStatistics.columnStatistics().keySet());
-        removedColumnStatistics.forEach(column -> deleteTableColumnStatistics(databaseName, tableName, column));
+        // Hive 4.0+ does not allow deleting column statistics for transactional tables via the standard API
+        if (!isTransactionalTable(originalTable)) {
+            removedColumnStatistics.forEach(column -> deleteTableColumnStatistics(databaseName, tableName, column));
+        }
+    }
+
+    private static boolean isTransactionalTable(Table table)
+    {
+        Map<String, String> parameters = table.getParameters();
+        return parameters != null && "true".equalsIgnoreCase(parameters.get("transactional"));
+    }
+
+    private Optional<String> getValidWriteIdList(String databaseName, String tableName, long writeId)
+    {
+        try {
+            return Optional.of(retry()
+                    .stopOnIllegalExceptions()
+                    .run("getValidWriteIds", stats.getValidWriteIds().wrap(() -> {
+                        try (ThriftMetastoreClient metastoreClient = createMetastoreClient()) {
+                            return metastoreClient.getValidWriteIds(
+                                    ImmutableList.of(format("%s.%s", databaseName, tableName)),
+                                    writeId);
+                        }
+                    })));
+        }
+        catch (Exception e) {
+            // If we can't get valid write IDs, return empty and fall back to non-transactional API
+            return Optional.empty();
+        }
     }
 
     private PartitionStatistics getCurrentTableStatistics(Table table)
@@ -453,13 +488,23 @@ public final class ThriftHiveMetastore
 
     private void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics)
     {
+        setTableColumnStatistics(databaseName, tableName, statistics, OptionalLong.empty(), Optional.empty());
+    }
+
+    private void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics, OptionalLong writeId, Optional<String> validWriteIdList)
+    {
         try {
             retry()
                     .stopOn(NoSuchObjectException.class, InvalidObjectException.class, MetaException.class, InvalidInputException.class)
                     .stopOnIllegalExceptions()
                     .run("setTableColumnStatistics", stats.getSetTableColumnStatistics().wrap(() -> {
                         try (ThriftMetastoreClient client = createMetastoreClient()) {
-                            client.setTableColumnStatistics(databaseName, tableName, statistics);
+                            if (writeId.isPresent() && validWriteIdList.isPresent()) {
+                                client.setTableColumnStatistics(databaseName, tableName, statistics, writeId.getAsLong(), validWriteIdList.get());
+                            }
+                            else {
+                                client.setTableColumnStatistics(databaseName, tableName, statistics);
+                            }
                             return null;
                         }
                     }));
@@ -532,7 +577,10 @@ public final class ThriftHiveMetastore
         setPartitionColumnStatistics(table.getDbName(), table.getTableName(), partitionName, columns, updatedStatistics.columnStatistics());
 
         Set<String> removedStatistics = difference(currentColumnStats.keySet(), updatedStatistics.columnStatistics().keySet());
-        removedStatistics.forEach(column -> deletePartitionColumnStatistics(table.getDbName(), table.getTableName(), partitionName, column));
+        // Hive 4.0+ does not allow deleting column statistics for transactional tables via the standard API
+        if (!isTransactionalTable(table)) {
+            removedStatistics.forEach(column -> deletePartitionColumnStatistics(table.getDbName(), table.getTableName(), partitionName, column));
+        }
     }
 
     private void setPartitionColumnStatistics(
@@ -1205,6 +1253,12 @@ public final class ThriftHiveMetastore
         // In case new partition had the statistics computed for all the columns, the storePartitionColumnStatistics
         // call in the alterPartition will just overwrite the old statistics. There is no need to explicitly remove anything.
         if (columnsWithMissingStatistics.isEmpty()) {
+            return;
+        }
+
+        // Hive 4.0+ does not allow deleting column statistics for transactional tables via the standard API
+        Optional<Table> table = getTable(databaseName, tableName);
+        if (table.isPresent() && isTransactionalTable(table.get())) {
             return;
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -453,7 +453,7 @@ public final class ThriftHiveMetastore
     private Optional<String> getValidWriteIdList(String databaseName, String tableName, long writeId)
     {
         try {
-            return Optional.of(retry()
+            return Optional.ofNullable(retry()
                     .stopOnIllegalExceptions()
                     .run("getValidWriteIds", stats.getValidWriteIds().wrap(() -> {
                         try (ThriftMetastoreClient metastoreClient = createMetastoreClient()) {
@@ -464,7 +464,9 @@ public final class ThriftHiveMetastore
                     })));
         }
         catch (Exception e) {
-            // If we can't get valid write IDs, return empty and fall back to non-transactional API
+            // If we can't get valid write IDs, log and fall back to non-transactional API
+            log.debug(e, "Unable to get valid write IDs for %s.%s with writeId %d, falling back to non-transactional API",
+                    databaseName, tableName, writeId);
             return Optional.empty();
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -66,6 +66,7 @@ import io.trino.hive.thrift.metastore.TxnToWriteId;
 import io.trino.hive.thrift.metastore.UnlockRequest;
 import io.trino.plugin.base.util.LoggingInvocationHandler;
 import io.trino.plugin.hive.metastore.thrift.MetastoreSupportsDateStatistics.DateStatisticsSupport;
+import io.trino.plugin.hive.util.AcidTables;
 import io.trino.spi.connector.RelationType;
 import jakarta.annotation.Nullable;
 import org.apache.thrift.TApplicationException;
@@ -278,8 +279,7 @@ public class ThriftHiveMetastoreClient
 
     private static boolean isTransactionalTable(Table table)
     {
-        return table.getParameters() != null &&
-                "true".equalsIgnoreCase(table.getParameters().get("transactional"));
+        return table.getParameters() != null && AcidTables.isTransactionalTable(table.getParameters());
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -262,7 +262,14 @@ public class ThriftHiveMetastoreClient
             CreateTableRequest request = new CreateTableRequest(tableToCreate);
             request.setProcessorCapabilities(ACID_PROCESSOR_CAPABILITIES);
             request.setProcessorIdentifier(ACID_PROCESSOR_IDENTIFIER);
-            client.createTableReq(request);
+            try {
+                client.createTableReq(request);
+            }
+            catch (TException e) {
+                // Fallback to legacy createTable if createTableReq is not supported by the metastore
+                log.debug(e, "createTableReq failed for table %s, falling back to createTable", table.getTableName());
+                client.createTable(tableToCreate);
+            }
         }
         else {
             client.createTable(tableToCreate);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -29,6 +29,7 @@ import io.trino.hive.thrift.metastore.ColumnStatistics;
 import io.trino.hive.thrift.metastore.ColumnStatisticsDesc;
 import io.trino.hive.thrift.metastore.ColumnStatisticsObj;
 import io.trino.hive.thrift.metastore.CommitTxnRequest;
+import io.trino.hive.thrift.metastore.CreateTableRequest;
 import io.trino.hive.thrift.metastore.DataOperationType;
 import io.trino.hive.thrift.metastore.Database;
 import io.trino.hive.thrift.metastore.EnvironmentContext;
@@ -55,6 +56,7 @@ import io.trino.hive.thrift.metastore.PrincipalType;
 import io.trino.hive.thrift.metastore.PrivilegeBag;
 import io.trino.hive.thrift.metastore.Role;
 import io.trino.hive.thrift.metastore.RolePrincipalGrant;
+import io.trino.hive.thrift.metastore.SetPartitionsStatsRequest;
 import io.trino.hive.thrift.metastore.Table;
 import io.trino.hive.thrift.metastore.TableMeta;
 import io.trino.hive.thrift.metastore.TableStatsRequest;
@@ -234,13 +236,43 @@ public class ThriftHiveMetastoreClient
         client.alterDatabase(prependCatalogToDbName(catalogName, databaseName), database);
     }
 
+    // Processor capabilities required for ACID table operations in Hive 3.x+
+    // These capabilities tell the Hive Metastore that the client can handle ACID tables
+    private static final List<String> ACID_PROCESSOR_CAPABILITIES = ImmutableList.of(
+            "HIVEFULLACIDREAD",
+            "HIVEFULLACIDWRITE",
+            "HIVEMANAGEDINSERTREAD",
+            "HIVEMANAGEDINSERTWRITE",
+            "HIVECACHEINVALIDATE",
+            "CONNECTORREAD",
+            "CONNECTORWRITE");
+
+    private static final String ACID_PROCESSOR_IDENTIFIER = "trino";
+
     @Override
     public void createTable(Table table)
             throws TException
     {
-        client.createTable(catalogName.isEmpty()
+        Table tableToCreate = catalogName.isEmpty()
                 ? table
-                : table.deepCopy().setCatName(catalogName.orElseThrow()));
+                : table.deepCopy().setCatName(catalogName.orElseThrow());
+
+        // Use createTableReq API with processor capabilities for ACID tables
+        if (isTransactionalTable(tableToCreate)) {
+            CreateTableRequest request = new CreateTableRequest(tableToCreate);
+            request.setProcessorCapabilities(ACID_PROCESSOR_CAPABILITIES);
+            request.setProcessorIdentifier(ACID_PROCESSOR_IDENTIFIER);
+            client.createTableReq(request);
+        }
+        else {
+            client.createTable(tableToCreate);
+        }
+    }
+
+    private static boolean isTransactionalTable(Table table)
+    {
+        return table.getParameters() != null &&
+                "true".equalsIgnoreCase(table.getParameters().get("transactional"));
     }
 
     @Override
@@ -304,6 +336,25 @@ public class ThriftHiveMetastoreClient
     }
 
     @Override
+    public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics, long writeId, String validWriteIdList)
+            throws TException
+    {
+        setColumnStatistics(
+                format("table %s.%s", databaseName, tableName),
+                statistics,
+                stats -> {
+                    ColumnStatisticsDesc statisticsDescription = new ColumnStatisticsDesc(true, databaseName, tableName);
+                    catalogName.ifPresent(statisticsDescription::setCatName);
+                    ColumnStatistics colStats = new ColumnStatistics(statisticsDescription, stats);
+                    SetPartitionsStatsRequest request = new SetPartitionsStatsRequest(ImmutableList.of(colStats));
+                    request.setWriteId(writeId);
+                    request.setValidWriteIdList(validWriteIdList);
+                    request.setEngine(engine);
+                    client.updateTableColumnStatisticsReq(request);
+                });
+    }
+
+    @Override
     public void deleteTableColumnStatistics(String databaseName, String tableName, String columnName)
             throws TException
     {
@@ -332,6 +383,26 @@ public class ThriftHiveMetastoreClient
                     statisticsDescription.setPartName(partitionName);
                     ColumnStatistics request = new ColumnStatistics(statisticsDescription, stats);
                     client.updatePartitionColumnStatistics(request);
+                });
+    }
+
+    @Override
+    public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics, long writeId, String validWriteIdList)
+            throws TException
+    {
+        setColumnStatistics(
+                format("partition of table %s.%s", databaseName, tableName),
+                statistics,
+                stats -> {
+                    ColumnStatisticsDesc statisticsDescription = new ColumnStatisticsDesc(false, databaseName, tableName);
+                    catalogName.ifPresent(statisticsDescription::setCatName);
+                    statisticsDescription.setPartName(partitionName);
+                    ColumnStatistics colStats = new ColumnStatistics(statisticsDescription, stats);
+                    SetPartitionsStatsRequest request = new SetPartitionsStatsRequest(ImmutableList.of(colStats));
+                    request.setWriteId(writeId);
+                    request.setValidWriteIdList(validWriteIdList);
+                    request.setEngine(engine);
+                    client.updatePartitionColumnStatisticsReq(request);
                 });
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -267,9 +267,15 @@ public class ThriftHiveMetastoreClient
                 client.createTableReq(request);
             }
             catch (TException e) {
-                // Fallback to legacy createTable if createTableReq is not supported by the metastore
-                log.debug(e, "createTableReq failed for table %s, falling back to createTable", table.getTableName());
-                client.createTable(tableToCreate);
+                // Only fallback to legacy createTable if createTableReq method doesn't exist on older metastores
+                // For all other errors (including ACID-specific errors), propagate the exception
+                if (isUnknownMethodExceptionalResponse(e)) {
+                    log.debug(e, "createTableReq not supported by metastore for table %s, falling back to createTable", table.getTableName());
+                    client.createTable(tableToCreate);
+                }
+                else {
+                    throw e;
+                }
             }
         }
         else {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -83,6 +83,9 @@ public interface ThriftMetastoreClient
     void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics)
             throws TException;
 
+    void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics, long writeId, String validWriteIdList)
+            throws TException;
+
     void deleteTableColumnStatistics(String databaseName, String tableName, String columnName)
             throws TException;
 
@@ -90,6 +93,9 @@ public interface ThriftMetastoreClient
             throws TException;
 
     void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics)
+            throws TException;
+
+    void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics, long writeId, String validWriteIdList)
             throws TException;
 
     void deletePartitionColumnStatistics(String databaseName, String tableName, String partitionName, String columnName)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -238,6 +238,12 @@ public class MockThriftMetastoreClient
     }
 
     @Override
+    public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics, long writeId, String validWriteIdList)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void deleteTableColumnStatistics(String databaseName, String tableName, String columnName)
     {
         throw new UnsupportedOperationException();
@@ -273,6 +279,13 @@ public class MockThriftMetastoreClient
 
     @Override
     public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics)
+    {
+        accessCount.incrementAndGet();
+        // No-op
+    }
+
+    @Override
+    public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics, long writeId, String validWriteIdList)
     {
         accessCount.incrementAndGet();
         // No-op

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -240,7 +240,8 @@ public class MockThriftMetastoreClient
     @Override
     public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics, long writeId, String validWriteIdList)
     {
-        throw new UnsupportedOperationException();
+        accessCount.incrementAndGet();
+        // No-op for mock
     }
 
     @Override


### PR DESCRIPTION
This PR adds read support for Hive ACID 4.0.1 tables in the Hive connector for Trino. It implements ACID-aware metadata parsing and layout discovery (base/delta/compacted), integrates ACID-aware split/reader handling so Trino reads the correct set of files for transactional tables, and includes tests and connector documentation updates to ensure compatibility with Hive ACID 4.0.1 layouts.