### PR TITLE
ODP-6000: Bump Pinot dependency version to 1.4.0.3.3.6.3-101 in trino-pinot plugin

### DIFF
--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -13,7 +13,7 @@
     <description>Trino - Pinot connector</description>
 
     <properties>
-        <dep.pinot.version>1.3.0.3.3.6.3-101</dep.pinot.version>
+        <dep.pinot.version>1.4.0.3.3.6.3-101</dep.pinot.version>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
         <!-- additional JVM flags required by chronicle-hft which is used by pinot-segment spi -->
         <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default}


### PR DESCRIPTION
This patch was tested locally.