### PR TITLE
OSV-10826 CVE-2025-30065 Update parquet to 1.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,8 +215,8 @@
         <dep.joda.version>2.13.1</dep.joda.version>
         <dep.jsonwebtoken.version>0.12.6</dep.jsonwebtoken.version>
         <dep.jts.version>1.20.0</dep.jts.version>
-        <dep.kafka-clients.version>3.7.2.3.3.6.3-1</dep.kafka-clients.version>
-        <dep.okio.version>3.9.1</dep.okio.version>
+        <dep.kafka-clients.version>3.7.2.3.2.3.6-2</dep.kafka-clients.version>
+        <dep.okio.version>3.10.2</dep.okio.version>
         <dep.parquet.version>1.15.2</dep.parquet.version>
         <dep.plugin.failsafe.version>${dep.plugin.surefire.version}</dep.plugin.failsafe.version>
         <dep.protobuf.version>3.25.6</dep.protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -215,9 +215,9 @@
         <dep.joda.version>2.13.1</dep.joda.version>
         <dep.jsonwebtoken.version>0.12.6</dep.jsonwebtoken.version>
         <dep.jts.version>1.20.0</dep.jts.version>
-        <dep.kafka-clients.version>3.7.2.3.2.3.6-2</dep.kafka-clients.version>
-        <dep.okio.version>3.10.2</dep.okio.version>
-        <dep.parquet.version>1.15.0</dep.parquet.version>
+        <dep.kafka-clients.version>3.7.2.3.3.6.3-1</dep.kafka-clients.version>
+        <dep.okio.version>3.9.1</dep.okio.version>
+        <dep.parquet.version>1.15.1</dep.parquet.version>
         <dep.plugin.failsafe.version>${dep.plugin.surefire.version}</dep.plugin.failsafe.version>
         <dep.protobuf.version>3.25.6</dep.protobuf.version>
         <dep.snowflake.version>3.23.0</dep.snowflake.version>

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <dep.jts.version>1.20.0</dep.jts.version>
         <dep.kafka-clients.version>3.7.2.3.3.6.3-1</dep.kafka-clients.version>
         <dep.okio.version>3.9.1</dep.okio.version>
-        <dep.parquet.version>1.15.1</dep.parquet.version>
+        <dep.parquet.version>1.15.2</dep.parquet.version>
         <dep.plugin.failsafe.version>${dep.plugin.surefire.version}</dep.plugin.failsafe.version>
         <dep.protobuf.version>3.25.6</dep.protobuf.version>
         <dep.snowflake.version>3.23.0</dep.snowflake.version>


### PR DESCRIPTION
<img width="758" height="246" alt="image" src="https://github.com/user-attachments/assets/6fa832b1-f925-4ff4-ac1f-8a4faa148008" />