### PR TITLE
OSV-10830 CVE-2025-5115 jetty bumped to 12.0.22 for trino-vertica plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,7 @@
         <!-- keep dependency properties sorted -->
         <dep.airlift.version>312</dep.airlift.version>
         <dep.launcher.version>314</dep.launcher.version>
+        <dep.jetty.version>12.0.22</dep.jetty.version>
         <dep.alluxio.version>2.9.6</dep.alluxio.version>
         <dep.antlr.version>4.13.2</dep.antlr.version>
         <dep.avro.version>1.12.0</dep.avro.version>


### PR DESCRIPTION
<img width="775" height="474" alt="image" src="https://github.com/user-attachments/assets/6d59735c-dbea-4f05-bd0a-5c4fada97960" />
