### PR TITLE
OSV-10790 CVE-2025-59419 Bump Netty to 4.1.128.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.127.Final</version>
+                <version>4.1.128.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
<img width="778" height="102" alt="image" src="https://github.com/user-attachments/assets/f10a47b1-64ad-425f-b33e-16af2c7729ba" />
