### PR TITLE
ODP-6128: Fix compilation issues for Trino

### DIFF
--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -14,7 +14,7 @@
     <description>Trino - Elasticsearch connector</description>
 
     <properties>
-        <dep.elasticsearch.version>7.17.28</dep.elasticsearch.version>
+        <dep.elasticsearch.version>7.17.29</dep.elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/plugin/trino-ranger/pom.xml
+++ b/plugin/trino-ranger/pom.xml
@@ -177,7 +177,7 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
-            <version>7.17.26</version>
+            <version>7.17.29</version>
             <scope>runtime</scope>
             <exclusions>
                 <exclusion>

--- a/plugin/trino-ranger/pom.xml
+++ b/plugin/trino-ranger/pom.xml
@@ -23,6 +23,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.13.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>4.5.13</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1912,7 +1912,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.17.0</version>
+                <version>3.18.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dep.snowflake.version>3.23.0</dep.snowflake.version>
         <dep.swagger.version>2.2.28</dep.swagger.version>
         <dep.takari.version>2.2.0</dep.takari.version>
-        <dep.tcnative.version>2.0.70.Final</dep.tcnative.version>
+        <dep.tcnative.version>2.0.75.Final</dep.tcnative.version>
         <dep.tempto.version>202</dep.tempto.version>
         <dep.wire.version>5.2.1</dep.wire.version>
         <dep.zookeeper.version>3.8.4.3.3.6.4-1</dep.zookeeper.version>

--- a/pom.xml
+++ b/pom.xml
@@ -643,6 +643,11 @@
                 <artifactId>commons-io</artifactId>
                 <version>2.18.0</version>
             </dependency>
+            <dependency>
+                <groupId>commons-text</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.13.1</version>
+            </dependency>
 
             <dependency>
                 <groupId>dev.failsafe</groupId>


### PR DESCRIPTION
This makes it possible to compile Trino for 3.3.6.4-1.