### PR TITLE
ODP-6890: Bump up Netty Version to 4.1.133.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.132.Final</version>
+                <version>4.1.133.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
It has been tested locally
