### PR TITLE
OSV-18909 - CVE - Bump Jetty 12.0.22 -> 12.0.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <!-- keep dependency properties sorted -->
         <dep.airlift.version>312</dep.airlift.version>
         <dep.launcher.version>314</dep.launcher.version>
-        <dep.jetty.version>12.0.22</dep.jetty.version>
+        <dep.jetty.version>12.0.33</dep.jetty.version>
         <dep.alluxio.version>2.9.6</dep.alluxio.version>
         <dep.antlr.version>4.13.2</dep.antlr.version>
         <dep.avro.version>1.12.0</dep.avro.version>


### PR DESCRIPTION
## CVE fix - Jetty

Bumps `dep.jetty.version` from **12.0.22** to **12.0.33** in the root `pom.xml`.

Resolves the following OSV/CVE tickets (Trino 3.2.3.6 baseline):

| OSV | CVE | Component | Fixed in |
| --- | --- | --- | --- |
| OSV-18909 / OSV-18955 | CVE-2026-2332 | jetty-io | 12.0.33 |
| OSV-18896 / OSV-18899 | CVE-2026-2332 | jetty-http | 12.0.33 |
| OSV-18903 / OSV-18910 | CVE-2026-1605 | jetty-server | 12.0.32 |
| OSV-18906 / OSV-18952 | CVE-2025-11143 | jetty-io | 12.0.31 |
| OSV-18913 / OSV-18920 | CVE-2025-5115 | jetty-http2-common | 12.0.25 |

12.0.33 covers all of the above. Build validated via CI.

Reviewer: @basapuram
