### PR TITLE
OSV-18949 - CVE - Bump aircompressor 2.0.2 -> 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -654,7 +654,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>2.0.2</version>
+                <version>2.0.3</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## CVE fix - aircompressor

Bumps `io.airlift:aircompressor` from **2.0.2** to **2.0.3** in the root `pom.xml`.

Resolves (Trino 3.2.3.6 baseline):

| OSV | CVE | Component | Fixed in |
| --- | --- | --- | --- |
| OSV-18949 / OSV-18956 | CVE-2025-67721 | io.airlift:aircompressor | 2.0.3 |

Build validated via CI.

Reviewer: @basapuram
