### PR TITLE
OSV-18944 - CVE - Bump Netty 4.1.133.Final -> 4.1.135.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## CVE fix - Netty (proactive hardening)

Bumps `io.netty:netty-bom` from **4.1.133.Final** to **4.1.135.Final** in the root `pom.xml`.

The netty-codec family CVEs on the 3.2.3.6 scan (4.1.132.Final) were already resolved on this branch by 4.1.133.Final; this bump moves to the latest 4.1.x for additional hardening.

Related tickets: OSV-18944, OSV-18946, OSV-18947, OSV-18958, OSV-18915, OSV-18923, OSV-18924, OSV-18925, OSV-18926, OSV-18927, OSV-18928.

Build validated via CI.

Reviewer: @basapuram
