### PR TITLE
OSV-23411: Bump netty to 4.1.135.Final (netty 4.1.1* CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.132.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Summary
- Bump Netty to **4.1.135.Final** to address CVEs reported against netty **4.1.1\*.Final**.

## Tickets (12)
OSV-23411, OSV-23426, OSV-23441, OSV-23464, OSV-23466, OSV-23469, OSV-23470, OSV-23471, OSV-23472, OSV-23473, OSV-23474, OSV-23478
