### PR TITLE
OSV-23421 - CVE - Bumped-up Jetty to 12.0.34 to address CVE-2025-11143/CVE-2026-1605/CVE-2026-2332/CVE-2026-5795

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,14 +299,14 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>12.0.25</version>
+                <version>12.0.34</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.ee10</groupId>
                 <artifactId>jetty-ee10-bom</artifactId>
-                <version>12.0.25</version>
+                <version>12.0.34</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
- Component: trino (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Jetty → 12.0.34
- Tickets: OSV-23421, OSV-23422, OSV-23423, OSV-23424, OSV-23427, OSV-23428, OSV-23446, OSV-23450, OSV-23451, OSV-23457, OSV-23458, OSV-23459, OSV-23460, OSV-23461
- Files: pom.xml