### PR TITLE
OSV-23419 - CVE - Bumped-up Jackson to 2.21.1 to address GHSA-72hv-8253-57qq

### DIFF
--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -27,21 +27,21 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.19.1</version>
+                <version>2.21.1</version>
             </dependency>
 
             <!-- jackson-core: 2.19.0 vs 2.19.1 -->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.19.1</version>
+                <version>2.21.1</version>
             </dependency>
 
             <!-- jackson-databind: 2.19.0 vs 2.19.1 -->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.19.1</version>
+                <version>2.21.1</version>
             </dependency>
 
             <!-- zstd-jni: 1.5.7-1 vs 1.5.7-4 -->

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,7 @@
         Since 1.1.0, the default behaviour for such conflicts changed from overwriting the artifact to failing the build.
         -->
         <provisio.fallbackTargetFileNameMode>GA</provisio.fallbackTargetFileNameMode>
+            <dep.jackson.version>2.21.1</dep.jackson.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- Component: trino (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Jackson → 2.21.1
- Tickets: OSV-23419, OSV-23447
- Files: pom.xml, plugin/trino-pinot/pom.xml