### PR TITLE
OSV-23462 - CVE - Bumped-up logback to 1.5.25 to address CVE-2025-11226/CVE-2026-1225

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,8 @@
         <dep.opentelemetry-alpha.version>1.62.0-alpha</dep.opentelemetry-alpha.version>
         <dep.opentelemetry-instrumentation.version>2.17.1</dep.opentelemetry-instrumentation.version>
         <dep.opentelemetry-instrumentation-alpha.version>2.17.1-alpha</dep.opentelemetry-instrumentation-alpha.version>
+    <dep.logback.version>1.5.25</dep.logback.version>
+
   </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- Component: trino (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: logback → 1.5.25
- Tickets: OSV-23462, OSV-23463, OSV-23476, OSV-23477
- Files: pom.xml