### PR TITLE
OSV-23420 - CVE - Bumped-up commons-configuration2 to 2.15.0 to address CVE-2026-45205

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,13 @@
 
     <dependencyManagement>
         <dependencies>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.15.0</version>
+            </dependency>
+
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>


### PR DESCRIPTION
- Component: trino (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-configuration2 → 2.15.0
- Tickets: OSV-23420, OSV-23448, OSV-23468, OSV-23475
- Files: pom.xml