### PR TITLE
OSV-23444 - CVE - Bumped-up grpc-netty-shaded to 1.75.0 to address CVE-2025-55163

### DIFF
--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -70,56 +70,56 @@
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-api</artifactId>
-                <version>1.73.0</version>
+                <version>1.75.0</version>
             </dependency>
 
             <!-- grpc-context: 1.70.0 vs 1.73.0 (transitive from grpc-core) -->
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-context</artifactId>
-                <version>1.73.0</version>
+                <version>1.75.0</version>
             </dependency>
 
             <!-- grpc-core: 1.70.0 vs 1.73.0 -->
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-core</artifactId>
-                <version>1.73.0</version>
+                <version>1.75.0</version>
             </dependency>
 
             <!-- grpc-netty-shaded: 1.70.0 vs 1.73.0 -->
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-netty-shaded</artifactId>
-                <version>1.73.0</version>
+                <version>1.75.0</version>
             </dependency>
 
             <!-- grpc-protobuf: 1.70.0 vs 1.73.0 -->
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-protobuf</artifactId>
-                <version>1.73.0</version>
+                <version>1.75.0</version>
             </dependency>
 
             <!-- grpc-protobuf-lite: 1.70.0 vs 1.73.0 -->
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-protobuf-lite</artifactId>
-                <version>1.73.0</version>
+                <version>1.75.0</version>
             </dependency>
 
             <!-- grpc-stub: 1.70.0 vs 1.73.0 -->
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-stub</artifactId>
-                <version>1.73.0</version>
+                <version>1.75.0</version>
             </dependency>
 
             <!-- grpc-util: 1.70.0 vs 1.73.0 -->
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-util</artifactId>
-                <version>1.73.0</version>
+                <version>1.75.0</version>
             </dependency>
 
             <!-- fastutil: 8.5.15 vs 8.5.16 -->

--- a/pom.xml
+++ b/pom.xml
@@ -2435,6 +2435,11 @@
                 <!-- This is under Confluent Community License and it should not be used with compile scope -->
                 <scope>test</scope>
             </dependency>
+        <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-netty-shaded</artifactId>
+                <version>1.75.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
- Component: trino (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: grpc-netty-shaded → 1.75.0
- Tickets: OSV-23444, OSV-23449
- Files: pom.xml, plugin/trino-pinot/pom.xml