### PR TITLE
OSV-23454 - CVE - Bumped-up bcprov-jdk18on to 1.84 to address CVE-2026-0636/CVE-2026-5598

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2442,6 +2442,11 @@
                 <artifactId>grpc-netty-shaded</artifactId>
                 <version>1.75.0</version>
             </dependency>
+        <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
- Component: trino (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: bcprov-jdk18on → 1.84
- Tickets: OSV-23454, OSV-23455
- Files: pom.xml