### PR TITLE
OSV-23425 - CVE - Bumped-up reactor-netty to 1.2.8 to address CVE-2025-22227

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,12 @@
 
     <dependencyManagement>
         <dependencies>
+<dependency>
+                <groupId>io.projectreactor.netty</groupId>
+                <artifactId>reactor-netty-http</artifactId>
+                <version>1.2.8</version>
+            </dependency>
+
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -946,7 +952,7 @@
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-core</artifactId>
-                <version>1.1.27</version>
+                <version>1.2.8</version>
             </dependency>
 
             <!-- io.confluent:kafka-avro-serializer uses multiple versions of this transitive dependency -->


### PR DESCRIPTION
- Component: trino (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: reactor-netty → 1.2.8
- Tickets: OSV-23425
- Files: pom.xml