### PR TITLE
OSV-23442 - CVE - Bumped-up snowflake-jdbc to 3.23.1 to address CVE-2025-27496/CVE-2026-3293

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <dep.parquet.version>1.15.2</dep.parquet.version>
         <dep.plugin.failsafe.version>${dep.plugin.surefire.version}</dep.plugin.failsafe.version>
         <dep.protobuf.version>3.25.6</dep.protobuf.version>
-        <dep.snowflake.version>3.23.0</dep.snowflake.version>
+        <dep.snowflake.version>3.23.1</dep.snowflake.version>
         <dep.swagger.version>2.2.28</dep.swagger.version>
         <dep.takari.version>2.2.0</dep.takari.version>
         <dep.tcnative.version>2.0.75.Final</dep.tcnative.version>


### PR DESCRIPTION
- Component: trino (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: snowflake-jdbc → 3.23.1
- Tickets: OSV-23442, OSV-23443
- Files: pom.xml