### PR TITLE
OSV-23456 - CVE - Bumped-up OpenTelemetry to 1.62.0 to address CVE-2026-45292

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,11 @@
         -->
         <provisio.fallbackTargetFileNameMode>GA</provisio.fallbackTargetFileNameMode>
             <dep.jackson.version>2.21.1</dep.jackson.version>
-    </properties>
+          <dep.opentelemetry.version>1.62.0</dep.opentelemetry.version>
+        <dep.opentelemetry-alpha.version>1.62.0-alpha</dep.opentelemetry-alpha.version>
+        <dep.opentelemetry-instrumentation.version>2.17.1</dep.opentelemetry-instrumentation.version>
+        <dep.opentelemetry-instrumentation-alpha.version>2.17.1-alpha</dep.opentelemetry-instrumentation-alpha.version>
+  </properties>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
- Component: trino (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: OpenTelemetry → 1.62.0
- Tickets: OSV-23456, OSV-23467
- Files: pom.xml