### PR TITLE
OSV-23465 - CVE - Bumped-up lz4-java to 1.10.1 to address CVE-2025-66566

### DIFF
--- a/plugin/trino-clickhouse/pom.xml
+++ b/plugin/trino-clickhouse/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <!-- Clickhouse client will by default use LZ4 compression, which requires this dependency -->
             <!-- https://github.com/ClickHouse/clickhouse-docs/pull/2408/files -->
-            <groupId>org.lz4</groupId>
+            <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2286,9 +2286,9 @@
             <dependency>
                 <!-- Clickhouse client will by default use LZ4 compression, which requires this dependency -->
                 <!-- https://github.com/ClickHouse/clickhouse-docs/pull/2408/files -->
-                <groupId>org.lz4</groupId>
+                <groupId>at.yawk.lz4</groupId>
                 <artifactId>lz4-java</artifactId>
-                <version>1.8.1</version>
+                <version>1.10.1</version>
             </dependency>
 
             <dependency>

--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -287,7 +287,7 @@
         <dependency>
             <!-- Clickhouse client will by default use LZ4 compression, which requires this dependency -->
             <!-- https://github.com/ClickHouse/clickhouse-docs/pull/2408/files -->
-            <groupId>org.lz4</groupId>
+            <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
- Component: trino (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: lz4-java → 1.10.1
- Tickets: OSV-23465
- Files: pom.xml, plugin/trino-clickhouse/pom.xml, testing/trino-product-tests/pom.xml