### PR TITLE
ODP-7385: Bump hadoop-shaded-guava and nimbus-jose-jwt pins to match hadoop

### DIFF
--- a/plugin/trino-ranger/pom.xml
+++ b/plugin/trino-ranger/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>org.apache.hadoop.thirdparty</groupId>
             <artifactId>hadoop-shaded-guava</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.0</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -602,7 +602,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>10.0.2</version>
+                <version>10.4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION


trino-ranger's direct hadoop-shaded-guava pin (1.3.0) and the root pom's managed nimbus-jose-jwt version (10.0.2) were stale relative to what Hadoop's hadoop-auth actually pulls in (1.4.0 / 10.4), causing a Maven Enforcer RequireUpperBoundDeps failure. Bumping both to match; neither library is imported directly by trino-ranger's own code.
