### PR TITLE
ODP-7385: Exclude hadoop-auth from ranger-plugins-audit in trino-ranger

### DIFF
--- a/plugin/trino-ranger/pom.xml
+++ b/plugin/trino-ranger/pom.xml
@@ -169,6 +169,10 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-auth</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-common</artifactId>
                 </exclusion>
             </exclusions>


### PR DESCRIPTION
hadoop-auth is a direct, unexcluded transitive dep of ranger-plugins-audit and duplicates classes already provided by Trino's own hadoop-apache shim (different content, since hadoop-auth tracks our patched Hadoop 3.3.6 line), failing the duplicate-finder-maven-plugin check. It also drags in reload4j/ slf4j-reload4j, which collide with Trino's own log4j-over-slf4j bridge. Excluding hadoop-auth resolves both; Ranger's audit code doesn't use its server-side auth-filter classes here - UserGroupInformation from hadoop-apache already covers Kerberos identity handling.
